### PR TITLE
Add "clicked" effect to all buttons as feedback

### DIFF
--- a/gui/button.cpp
+++ b/gui/button.cpp
@@ -37,6 +37,10 @@ GUIButton::GUIButton(xml_node<>* node)
     mButtonLabel = NULL;
     mAction = NULL;
     mRendered = false;
+    highlightRenderCount = 0;
+
+    memset(&mHighlightColor, 0, sizeof(COLOR));
+    ConvertStrToColor("#90909080", &mHighlightColor);
 
     if (!node)  return;
 
@@ -96,7 +100,16 @@ int GUIButton::Render(void)
         gr_blit(mButtonIcon->GetResource(), 0, 0, mIconW, mIconH, mIconX, mIconY);
     if (mButtonLabel)   ret = mButtonLabel->Render();
     if (ret < 0)        return ret;
-    mRendered = true;
+
+    if (highlightRenderCount != 0)
+	{
+        gr_color(mHighlightColor.red, mHighlightColor.green, mHighlightColor.blue, mHighlightColor.alpha);
+        gr_fill(mRenderX, mRenderY, mRenderW, mRenderH);
+        if (highlightRenderCount > 0)
+            --highlightRenderCount;
+    }
+    else
+        mRendered = true;
     return ret;
 }
 
@@ -207,11 +220,13 @@ int GUIButton::NotifyTouch(TOUCH_STATE state, int x, int y)
 				mButtonLabel->isHighlighted = true;
 			if (mButtonImg != NULL)
 				mButtonImg->isHighlighted = true;
+			highlightRenderCount = 1;
 			mRendered = false;
 		}
 	}
 	if (x < mRenderX || x - mRenderX > mRenderW || y < mRenderY || y - mRenderY > mRenderH)
 		return 0;
+
     return (mAction ? mAction->NotifyTouch(state, x, y) : 1);
 }
 

--- a/gui/objects.hpp
+++ b/gui/objects.hpp
@@ -355,6 +355,8 @@ protected:
     int mTextX, mTextY, mTextW, mTextH;
     int mIconX, mIconY, mIconW, mIconH;
     bool mRendered;
+    int highlightRenderCount;
+    COLOR mHighlightColor;
 };
 
 class GUICheckbox: public RenderObject, public ActionObject, public Conditional


### PR DESCRIPTION
Add feedback to all buttons in TWRP. It is very annoying not to know if one just missed the button, or if it is doing something, especially in the "Mount" section and when rebooting, as it does umounting, which can take a while.
It looks pretty much like the highlight in keyboard (I kinda copy-pasted from that). Perhaps the color could be moved into xml files, but I don't think that it is necessary, because it is just half-transparent "something" color.

PS: you should really decide if you wanna to indent with tabs or with spaces.
