### PR TITLE
Allow init.rc inheritance and bring init.rc closer to CM recovery source

### DIFF
--- a/etc/init.rc
+++ b/etc/init.rc
@@ -1,3 +1,5 @@
+import /init.recovery.${ro.hardware}.rc
+
 on early-init
     start ueventd
 
@@ -10,10 +12,30 @@ on init
 
     symlink /system/etc /etc
 
+    mkdir /boot
+    mkdir /recovery
+    mkdir /sdcard
+    mkdir /internal_sd
+    mkdir /external_sd
+    mkdir /sd-ext
+    mkdir /datadata
+    mkdir /emmc
     mkdir /system
     mkdir /data
     mkdir /cache
     mount /tmp /tmp tmpfs
+
+    chown root shell /tmp
+    chmod 0775 /tmp
+
+    write /sys/class/android_usb/android0/enable 0
+    write /sys/class/android_usb/android0/idVendor 18D1
+    write /sys/class/android_usb/android0/idProduct D001
+    write /sys/class/android_usb/android0/functions adb
+    write /sys/class/android_usb/android0/iManufacturer ${ro.product.manufacturer}
+    write /sys/class/android_usb/android0/iProduct ${ro.product.model}
+    write /sys/class/android_usb/android0/iSerial ${ro.serialno}
+
 
 on boot
 
@@ -32,17 +54,9 @@ service adbd /sbin/adbd recovery
     disabled
 
 # Always start adbd on userdebug and eng builds
-# In recovery, always run adbd as root.
 on property:ro.debuggable=1
-    write /sys/class/android_usb/android0/enable 0
-    write /sys/class/android_usb/android0/idVendor 18D1
-    write /sys/class/android_usb/android0/idProduct D001
-    write /sys/class/android_usb/android0/functions adb
-    #write /sys/class/android_usb/android0/enable 1
-    write /sys/class/android_usb/android0/iManufacturer $ro.product.manufacturer
-    write /sys/class/android_usb/android0/iProduct $ro.product.model
-    write /sys/class/android_usb/android0/iSerial $ro.serialno
-    #start adbd
+    write /sys/class/android_usb/android0/enable 1
+    start adbd
     setprop service.adb.root 1
 
 # Restart adbd so it can run as root


### PR DESCRIPTION
The inheritance line (Line 1) allows a default init.rc script to be supplemented by additional needed services without requiring the device maintainer to write an entire init script.  This benefits device maintainers as the TeamWin source can always keep init.rc up-to-date without requiring devices update individually.

For an example of how device maintainers can take advantage of this feature, see this commit: https://github.com/CyanogenMod/android_device_htc_msm8960-common/commit/c951e40c82ba24b10bb7c0e890ca2a041eb683a0

It has been tested successfully on my htc fireball.

The source has also been re-organized to mimic CWM for easier comparisons between the two recoveries.
