### PR TITLE
Add command to disable double buffering

### DIFF
--- a/minuitwrp/Android.mk
+++ b/minuitwrp/Android.mk
@@ -140,6 +140,10 @@ else
     LOCAL_SRC_FILES += truetype.c
 endif
 
+ifeq ($(TW_DISABLE_DOUBLE_BUFFERING), true)
+    LOCAL_CFLAGS += -DTW_DISABLE_DOUBLE_BUFFERING
+endif
+
 LOCAL_CFLAGS += -DTWRES=\"$(TWRES_PATH)\"
 LOCAL_SHARED_LIBRARIES += libz libc libcutils libjpeg libpng
 LOCAL_STATIC_LIBRARIES += libpixelflinger_static

--- a/minuitwrp/graphics.c
+++ b/minuitwrp/graphics.c
@@ -298,7 +298,11 @@ static int get_framebuffer(GGLSurface *fb)
     if (vi.yres * fi.line_length * 2 > fi.smem_len)
         return fd;
 
+#ifdef TW_DISABLE_DOUBLE_BUFFERING
+    double_buffering = 0;
+#else
     double_buffering = 1;
+#endif
 
     fb->version = sizeof(*fb);
     fb->width = vi.xres;


### PR DESCRIPTION
I found on the device I was working with (Newsmy Carpad2 which is RK3188), that this just wasn't working properly all the time.
