### PR TITLE
Prevent no-SU prompt if no OS is installed

### DIFF
--- a/twrp.cpp
+++ b/twrp.cpp
@@ -341,7 +341,7 @@ int main(int argc, char **argv) {
 	TWFunc::Disable_Stock_Recovery_Replace();
 	// Check for su to see if the device is rooted or not
 	if (PartitionManager.Mount_By_Path("/system", false)) {
-		if (TWFunc::Path_Exists("/supersu/su") && !TWFunc::Path_Exists("/system/bin/su") && !TWFunc::Path_Exists("/system/xbin/su") && !TWFunc::Path_Exists("/system/bin/.ext/.su")) {
+		if (TWFunc::Path_Exists("/supersu/su") && TWFunc::Path_Exists("/system/bin") && !TWFunc::Path_Exists("/system/bin/su") && !TWFunc::Path_Exists("/system/xbin/su") && !TWFunc::Path_Exists("/system/bin/.ext/.su")) {
 			// Device doesn't have su installed
 			DataManager::SetValue("tw_busy", 1);
 			if (gui_startPage("installsu", 1, 1) != 0) {


### PR DESCRIPTION
Offer SU installation only if /system/bin exists to prevent TWRP for prompting to install SuperSU if no OS is installed.

This should fix #482 
