### PR TITLE
fix: add missing class field initialization in GUIProgressbar

### DIFF
--- a/gui/progressbar.cpp
+++ b/gui/progressbar.cpp
@@ -35,6 +35,7 @@ GUIProgressBar::GUIProgressBar(xml_node<>* node) : GUIObject(node)
 	mLastPos = 0;
 	mSlide = 0.0;
 	mSlideInc = 0.0;
+	mSlideFrames = 0;
 
 	if (!node)
 	{


### PR DESCRIPTION
mSlideFrames is not initialized in **GUIProgressbar constructor**.
