### PR TITLE
mkfs.f2fs: it doesn't support -r attribute

### DIFF
--- a/partition.cpp
+++ b/partition.cpp
@@ -2212,8 +2212,6 @@ bool TWPartition::Wipe_F2FS() {
 			if (Length < 0)
 				mod_length *= -1;
 			sprintf(len, "%i", mod_length);
-			command += " -r ";
-			command += len;
 		}
 		command += " " + Actual_Block_Device;
 		if (TWFunc::Exec_Cmd(command) == 0) {


### PR DESCRIPTION
changing fs to f2fs throws and error due to the presence of -r attribute.